### PR TITLE
add new function to remove extra keys from UpdateResult.raw_result

### DIFF
--- a/amostra/server/engine.py
+++ b/amostra/server/engine.py
@@ -187,7 +187,7 @@ class SampleReferenceHandler(DefaultHandler):
         res = database.sample.update_many(filter=query,
                                           update={'$set': update},
                                           upsert=False)
-        self.finish(ujson.dumps(res.raw_result))
+        self.finish(ujson.dumps(utils.sanitize_return(res.raw_result)))
 
 
 class RequestReferenceHandler(DefaultHandler):
@@ -274,7 +274,7 @@ class RequestReferenceHandler(DefaultHandler):
         res = database.request.update_many(filter=query,
                                            update={'$set': update},
                                            upsert=False)
-        self.finish(ujson.dumps(res.raw_result))
+        self.finish(ujson.dumps(utils.sanitize_return(res.raw_result)))
 
 
 class ContainerReferenceHandler(DefaultHandler):
@@ -367,7 +367,7 @@ class ContainerReferenceHandler(DefaultHandler):
         res = database.container.update_many(filter=query,
                                              update={'$set': update},
                                              upsert=False)
-        self.finish(ujson.dumps(res.raw_result))
+        self.finish(ujson.dumps(utils.sanitize_return(res.raw_result)))
 
 
 class SchemaHandler(DefaultHandler):

--- a/amostra/server/utils.py
+++ b/amostra/server/utils.py
@@ -100,3 +100,8 @@ def default_timeuid(document):
     if 'time' not in document or document['time'] is None:
         document['time'] = ttime.time()
     return document
+
+def sanitize_return(result_dict):
+    OLD_KEYS = set(['electionId', 'opTime', '$clusterTime', 'signature', 'operationTime'])
+    cleaned_result_dict = {k: v for k, v in result_dict.items() if k not in OLD_KEYS}
+    return cleaned_result_dict


### PR DESCRIPTION
 * the result from update contains more keys when run on a database
   that has replica sets. remove these extra keys to prevent
   ujson exceptions of being unable to serialize Timestamp() objects
 * same change as for conftrak