### PR TITLE
remove mongomock from conda install, make separate pip install

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,8 @@ jobs:
         if: matrix.dependencies == 'conda'
         run: |
           set -vxeo pipefail
-          conda install -y -c conda-forge doct jsonschema mongomock mongoquery pymongo pytest pyyaml requests six tornado ujson
+          conda install -y -c conda-forge doct jsonschema mongoquery pymongo pytest pyyaml requests six tornado ujson
+          pip install mongomock
 
       - name: Install the package
         run: |


### PR DESCRIPTION
 * for conda testing, use pip installed mongomock so that the version used is the same as with the pip install
   * due to lack of updates to conda-forge packages